### PR TITLE
Remove all references to kineircd as the project never materialized

### DIFF
--- a/_data/chanmembers.yaml
+++ b/_data/chanmembers.yaml
@@ -138,20 +138,6 @@ values:
             according to the RFC.
 
     -
-        name: SERVICE
-        prefixchar: "!"
-        mode: "!"
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            This is given only by servers or services. It should always be
-            the highest ranking membership type in the channel, and denotes
-            that the user with the membership status is a service. The
-            intended use for this was to mark out which channel member is an
-            official channel service, however other applications are also
-            available.
-
-    -
         name: FOUNDER
         prefixchar: "."
         mode: u

--- a/_data/chanmodes.yaml
+++ b/_data/chanmodes.yaml
@@ -523,14 +523,3 @@ values:
         comment: >
             Only allows clients connected via secure connections to join
             (eg. SSL)
-
-    -
-        char: "!"
-        name: SERVICE
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        parameter: Nickname
-        comment: >
-            Gives the specified nickname a marker (a '!') to show that it is
-            a service (i.e. a channel service). This is to help users
-            identify legitimate services on channels

--- a/_data/chantypes.yaml
+++ b/_data/chantypes.yaml
@@ -124,31 +124,3 @@ values:
             are set but don't announce them as being set.
 
         clientcreate: Y
-
-    -
-        name: SOFTCHAN
-        prefixchar: "."
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            This is a programmable channel type. Normal users cannot create
-            channels of this type. Channels must be created by the software
-            that controls them. The parameters of these channels are not set
-            in stone, and are controlled entirely by software. This means
-            '.' channels of different names may have different properties.
-            The function of this channel type is to provide set channels
-            which require rare features without channel mode bloat, or
-            software bloat. By creating a new channel type it also avoids
-            confusion with other channel types with fixed definitions.
-
-    -
-        prefixchar: "~"
-        name: GLOBAL
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            This is a proposed channel type for IIRC. This is available to
-            all IRC networks visible on an IIRC network, and as such users
-            from other networks can participate.
-
-        clientcreate: Y

--- a/_data/ircnumerics.yaml
+++ b/_data/ircnumerics.yaml
@@ -117,18 +117,6 @@ values:
         comment: Part of the post-registration greeting
 
     -
-        name: RPL_MYINFO
-        numeric: "004"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<server_name> <version> <user_modes> <chan_modes> <channel_modes_with_params> <user_modes_with_params> <server_modes> <server_modes_with_params>"
-        comment: >
-            Same as RFC2812 however with additional fields to avoid
-            additional 005 burden.
-
-        repeated: true
-
-    -
         name: RPL_BOUNCE
         numeric: "005"
         origin: RFC2812
@@ -1109,18 +1097,6 @@ values:
             away
 
     -
-        name: RPL_AWAY
-        numeric: "301"
-        origin: KineIRCd
-        format: "<nick> <seconds away> :<message>"
-        comment: >
-            Identical to RPL_AWAY, however this includes the number of
-            seconds the user has been away for. This is designed to
-            discourage the need for people to use those horrible scripts
-            which set the AWAY message every 30 seconds in order to include
-            an 'away since' timer.
-
-    -
         name: RPL_USERHOST
         numeric: "302"
         origin: RFC1459
@@ -1644,7 +1620,7 @@ values:
         format: "<channel> <banid> [<time_left> :<reason>]"
         comment: >
             A ban-list item (See RFC); <time left> and <reason> are
-            additions used by KineIRCd
+            additions used by various servers.
 
     -
         name: RPL_ENDOFBANLIST
@@ -3277,98 +3253,6 @@ values:
         obsolete: true
 
     -
-        name: RPL_TRACEROUTE_HOP
-        numeric: "660"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<target> <hop#> [<address> [<hostname> | '*'] <usec_ping>]"
-        comment: >
-            Returned from the TRACEROUTE IRC-Op command when tracerouting a
-            host
-
-    -
-        name: RPL_TRACEROUTE_START
-        numeric: "661"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<target> <target_FQDN> <target_address> <max_hops>"
-        comment: Start of an RPL_TRACEROUTE_HOP list
-
-    -
-        name: RPL_MODECHANGEWARN
-        numeric: "662"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "['+' | '-']<mode_char> :<warning>"
-        comment: >
-            Plain text warning to the user about turning on or off a user
-            mode. If no '+' or '-' prefix is used for the mode char, '+' is
-            presumed.
-
-    -
-        name: RPL_CHANREDIR
-        numeric: "663"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<old_chan> <new_chan> :<info>"
-        comment: >
-            Used to notify the client upon JOIN that they are joining a
-            different channel than expected because the IRC Daemon has been
-            set up to map the channel they attempted to join to the channel
-            they eventually will join.
-
-    -
-        name: RPL_SERVMODEIS
-        numeric: "664"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<server> <modes> <parameters>.."
-        comment: >
-            Reply to MODE <servername>. KineIRCd supports server modes to
-            simplify configuration of servers; Similar to RPL_CHANNELMODEIS
-
-    -
-        name: RPL_OTHERUMODEIS
-        numeric: "665"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<nickname> <modes>"
-        comment: >
-            Reply to MODE <nickname> to return the user-modes of another
-            user to help troubleshoot connections, etc. Similar to
-            RPL_UMODEIS, however including the target
-
-    -
-        name: RPL_ENDOF_GENERIC
-        numeric: "666"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<command> [<parameter> ...] :<info>"
-        comment: Generic response for new lists to save numerics.
-
-    -
-        name: RPL_WHOWASDETAILS
-        numeric: "670"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<nick> <type> :<information>"
-        comment: >
-            Returned by WHOWAS to return extended information (if
-            available). The type field is a number indication what kind of
-            information.
-
-    -
-        name: RPL_WHOISSECURE
-        numeric: "671"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<nick> <type> [:<info>]"
-        comment: >
-            Reply to WHOIS command - Returned if the target is connected
-            securely, eg. type may be TLSv1, or SSLv2 etc. If the type is
-            unknown, a '*' may be used.
-
-    -
         name: RPL_UNKNOWNMODES
         numeric: "672"
         origin: Ithildin
@@ -3387,100 +3271,6 @@ values:
         comment: >
             Returns a full list of modes that cannot be set when a client
             issues a MODE command
-
-    -
-        name: RPL_LUSERSTAFF
-        numeric: "678"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<staff_online_count> :<info>"
-        comment: >
-            Reply to LUSERS command - Number of network staff (or 'helpers')
-            online (differs from Local/Global operators). Similar format to
-            RPL_LUSEROP
-
-    -
-        name: RPL_TIMEONSERVERIS
-        numeric: "679"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<seconds> [<nanoseconds> | '0'] <timezone> <flags> :<info>"
-        comment: >
-            Optionally sent upon connection, and/or sent as a reply to the
-            TIME command. This returns the time on the server in a uniform
-            manner. The seconds (and optionally nanoseconds) is the time
-            since the UNIX Epoch, and is used since many existing timestamps
-            in the IRC-2 protocol are done this way (i.e. ban lists). The
-            timezone is hours and minutes each of Greenwich ('[+/-]HHMM').
-            Since all timestamps sent from the server are in a similar
-            format, this numeric is designed to give clients the ability to
-            provide accurate timestamps to their users.
-
-    -
-        name: RPL_NETWORKS
-        numeric: "682"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        information: >
-            http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/kineircd/kineircd/doc/IIRC?rev=HEAD
-
-        format: "<name> <through_name> <hops> :<info>"
-        comment: >
-            A reply to the NETWORKS command when requesting a list of known
-            networks (within the IIRC domain).
-
-    -
-        name: RPL_YOURLANGUAGEIS
-        numeric: "687"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        information: >
-            http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/kineircd/kineircd/doc/LANGUAGE?rev=HEAD
-
-        format: "<code(s)> :<info>"
-        comment: >
-            Reply to the LANGUAGE command, informing the client of the
-            language(s) it has set
-
-    -
-        name: RPL_LANGUAGE
-        numeric: "688"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        information: >
-            http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/kineircd/kineircd/doc/LANGUAGE?rev=HEAD
-
-        format: "<code> <revision> <maintainer> <flags> * :<info>"
-        comment: >
-            A language reply to LANGUAGE when requesting a list of known
-            languages
-
-    -
-        name: RPL_WHOISSTAFF
-        numeric: "689"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: ":<info>"
-        comment: >
-            The user is a staff member. The information may explain the
-            user's job role, or simply state that they are a part of the
-            network staff. Staff members are not IRC operators, but rather
-            people who have special access in association with network
-            services. KineIRCd uses this numeric instead of the existing
-            numerics due to the overwhelming number of conflicts.
-
-    -
-        name: RPL_WHOISLANGUAGE
-        numeric: "690"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        information: >
-            http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/kineircd/kineircd/doc/LANGUAGE?rev=HEAD
-
-        format: "<nick> <language codes>"
-        comment: >
-            Reply to WHOIS command - A list of languages someone can speak.
-            The language codes are comma delimitered.
 
     -
         name: RPL_MODLIST
@@ -3990,122 +3780,8 @@ values:
         numeric: "972"
         origin: Unreal
         comment: >
-            Works similarly to all of KineIRCd's CANNOT* numerics. This one
-            indicates that a command could not be performed for an arbitrary
+            Indicates that a command could not be performed for an arbitrary
             reason. For example, a halfop trying to kick an op.
-
-    -
-        name: ERR_CANNOTCHANGEUMODE
-        numeric: "973"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<mode_char> :<reason>"
-        comment: Reply to MODE when a user cannot change a user mode
-
-    -
-        name: ERR_CANNOTCHANGECHANMODE
-        numeric: "974"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<mode_char> :<reason>"
-        comment: Reply to MODE when a user cannot change a channel mode
-
-    -
-        name: ERR_CANNOTCHANGESERVERMODE
-        numeric: "975"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<mode_char> :<reason>"
-        comment: Reply to MODE when a user cannot change a server mode
-
-    -
-        name: ERR_CANNOTSENDTONICK
-        numeric: "976"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<nick> :<reason>"
-        comment: >
-            Returned from NOTICE, PRIVMSG or other commands to notify the
-            user that they cannot send a message to a particular client.
-            Similar to ERR_CANNOTSENDTOCHAN. KineIRCd uses this in
-            conjunction with user-mode +R to allow users to block people who
-            are not identified to services (spam avoidance)
-
-    -
-        name: ERR_UNKNOWNSERVERMODE
-        numeric: "977"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<modechar> :<info>"
-        comment: >
-            Returned by MODE to inform the client they used an unknown
-            server mode character.
-
-    -
-        name: ERR_SERVERMODELOCK
-        numeric: "979"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<target> :<info>"
-        comment: >
-            Returned by MODE to inform the client the server has been set
-            mode +L by an administrator to stop server modes being changed
-
-    -
-        name: ERR_BADCHARENCODING
-        numeric: "980"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<command> <charset> :<info>"
-        comment: >
-            Returned by any command which may have had the given data
-            modified because one or more glyphs were incorrectly encoded in
-            the current charset (given). Such a use would be where an
-            invalid UTF-8 sequence was given which may be considered
-            insecure, or defines a character which is invalid within that
-            context. For safety reasons, the invalid character is not
-            returned to the client.
-
-    -
-        name: ERR_TOOMANYLANGUAGES
-        numeric: "981"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        information: >
-            http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/kineircd/kineircd/doc/LANGUAGE?rev=HEAD
-
-        format: "<max_langs> :<info>"
-        comment: >
-            Returned by the LANGUAGE command to tell the client they cannot
-            set as many languages as they have requested. To assist the
-            client, the maximum languages which can be set at one time is
-            given, and the language settings are not changed.
-
-    -
-        name: ERR_NOLANGUAGE
-        numeric: "982"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        information: >
-            http://cvs.sourceforge.net/cgi-bin/viewcvs.cgi/kineircd/kineircd/doc/LANGUAGE?rev=HEAD
-
-        format: "<language_code> :<info>"
-        comment: >
-            Returned by the LANGUAGE command to tell the client it has
-            specified an unknown language code.
-
-    -
-        name: ERR_TEXTTOOSHORT
-        numeric: "983"
-        origin: KineIRCd
-        contact: "mailto:kineircd@alien.net.au"
-        format: "<command> :<info>"
-        comment: >
-            Returned by any command requiring text (such as a message or a
-            reason), which was not long enough to be considered valid. This
-            was created initially to combat '/wallops foo' abuse, but is
-            also used by DIE and RESTART commands to attempt to encourage
-            meaningful reasons.
 
     -
         name: ERR_NUMERIC_ERR

--- a/_data/servermodes.yaml
+++ b/_data/servermodes.yaml
@@ -99,58 +99,6 @@ format:
 
 values:
     -
-        char: a
-        name: AUTOCONNECT
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            Follow the autoconnect rules - When set on, the server should
-            follow autoconnect parameters given in the configuration file to
-            maintain its connection to the network.
-
-        broadcast: Y
-
-    -
-        char: A
-        name: AUTO_TBS
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            Automatically switch bone/tendril links. This is used in
-            association with server to server protocols which have redundant
-            links to specify whether or not the server should be actively
-            monitoring links to see if a better 'bone' can be selected. When
-            on, this gives the server the right to switch bone connections
-            around to benifit the network.
-
-        broadcast: Y
-
-    -
-        char: D
-        name: DEBUGGING
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            Turns debugging on (if available), or shows a server which is in
-            debugging mode.
-
-        broadcast: Y
-
-    -
-        char: F
-        name: FULL
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            A server turns toggles this depending on its 'fullness'. If the
-            server is full, either no more file descriptors are left, or all
-            connection classes are full, then this is a warning to other
-            servers not to redirect clients to it.
-
-        server_only: Y
-        broadcast: Y
-
-    -
         char: h
         name: HUB
         origin: ircu
@@ -163,66 +111,6 @@ values:
         broadcast: Y
 
     -
-        char: H
-        name: HIDDEN
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            When set, the server should be completely hidden to users. This
-            is different to masking the server's name. This allows for
-            invisible hubs, or invisible servers which host network
-            services, etc.
-
-        broadcast: Y
-
-    -
-        char: l
-        name: LAZY_LEAF
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            Server should consider itself a lazy leaf link to the network.
-            This means only one connection can be made to the server, and it
-            runs on lazy principles. The idea for lazy leafs comes from
-            Hybrid.
-
-        broadcast: Y
-
-    -
-        char: L
-        name: DEFAULT_LANGUAGE
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        parameter: <language code>
-        comment: >
-            Marks the given language code as the 'default' language for that
-            server. Language codes are that prescribed by BCP-0047, and only
-            one can be set at a time.
-
-        broadcast: Y
-
-    -
-        char: M
-        name: MODES_LOCKED
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            The server modes are locked, and can only be changed by other
-            servers. This is useful when servers shouldn't not be touched by
-            operators. Arbiters/U:lines servers can still change modes (i.e.
-            to remove this mode!)
-
-        broadcast: Y
-
-    -
-        char: n
-        name: NO_OPER
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: "When set, the OPER command is rendered useless"
-        broadcast: Y
-
-    -
         char: s
         name: SERVICE
         origin: ircu
@@ -232,20 +120,4 @@ values:
             services). In ircu, this also hides the server from users.
 
         server_only: Y
-        broadcast: Y
-
-    -
-        char: T
-        name: TESTLINK
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        comment: >
-            Mark the server as being under a 'testlink' period. Many
-            networks give new servers a testing period to give both the
-            server administrator, and the network, time to evaluate whether
-            or not the server will be able to remain permanent. Depending on
-            network policy, testlink server administrators may have
-            restricted rights, such as not being able to send global
-            messages. This flag aids to enforce those policies.
-
         broadcast: Y

--- a/_data/usermodes.yaml
+++ b/_data/usermodes.yaml
@@ -177,19 +177,6 @@ values:
 
     -
         char: d
-        name: DEAF
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        parameter: Prefix character
-        comment: >
-            User does not receive channel messages unless they are prefixed
-            with the given prefix character. If no parameter is given, all
-            channel messages are ignored, with no prefix checking.
-
-        conflict: true
-
-    -
-        char: d
         name: DEBUG
         origin: "Hybrid, Bahamut"
         comment: User receives debugging messages
@@ -222,7 +209,7 @@ values:
     -
         char: g
         name: CALLERID
-        origin: "Hybrid, KineIRCd"
+        origin: "Hybrid"
         comment: >
             User is ignoring everyone, unless they are ACCEPTed with the
             ACCEPT command
@@ -247,18 +234,6 @@ values:
         name: HELPER
         origin: "Bahamut, AustHex"
         comment: "User is a HELPER, associated with network services"
-        server_on: Y
-
-    -
-        char: h
-        name: HELPER
-        origin: KineIRCd
-        contact: kineircd@alien.net.au
-        parameter: level
-        comment: >
-            User is a HELPER, the level is an unsigned 16-bit integer
-            denotes 'rank', as determined by network services
-
         server_on: Y
 
     -
@@ -394,7 +369,7 @@ values:
     -
         char: R
         name: NO_NON_REGISTERED
-        origin: "Bahamut, KineIRCd, Unreal"
+        origin: "Bahamut, Unreal"
         server_on: Y
         server_off: Y
         comment: User wants to block messages from non-registered nicknames
@@ -419,7 +394,7 @@ values:
     -
         char: s
         name: SERVER_NOTICES
-        origin: "KineIRCd, Unreal"
+        origin: "Unreal"
         parameter: Notice mask list
         comment: >
             User receives server notices. The notice masks are normally a


### PR DESCRIPTION
The [kineircd repo](http://kineircd.cvs.sourceforge.net/viewvc/kineircd/kineircd) barely contains any code, so it's safe to remove references to this project as it's impossible that any running kineircd server exists.
