### PR TITLE
Lounge supports echo-message

### DIFF
--- a/_data/selfmessage.yaml
+++ b/_data/selfmessage.yaml
@@ -171,7 +171,6 @@ values:
       works: true
 
     - name: The Lounge
-      requested-caps: znc.in/self-message
       works: true
 
     - name: Weechat


### PR DESCRIPTION
Lounge supports `echo-message` via `irc-framework`, and the client itself also additionally requests `znc.in/self-message`.

Unless it is implied in the doc that both are supported, then this can be ignored.