### PR TITLE
Update formatting support for The Lounge

### DIFF
--- a/_data/formatting.yaml
+++ b/_data/formatting.yaml
@@ -29,9 +29,9 @@ page:
     extra_bottom: >
       <p>
           <strong>Tested Clients:</strong><br/>
-          AdiIRC 2.7, BitchX 1.2.1, Hexchat 2.12.4, IceChat 9.15, Instantbird 1.5, IRCCloud (2017-08-05), irssi 0.8.20, KiwiIRC (2017-07-09), Konversation 1.6 (#4910), KVIrc 4.9.2, mIRC 7.48, Quassel 0.12.4 (90183ee), WeeChat 1.7
+          AdiIRC 2.7, BitchX 1.2.1, Hexchat 2.12.4, IceChat 9.15, Instantbird 1.5, IRCCloud (2017-08-05), irssi 0.8.20, KiwiIRC (2017-07-09), Konversation 1.6 (#4910), KVIrc 4.9.2, The Lounge v2.7.0, mIRC 7.48, Quassel 0.12.4 (90183ee), WeeChat 1.7
 
-          <!--The Lounge, VisualIRC?, Textual, Colloquy-->
+          <!--VisualIRC?, Textual, Colloquy-->
       </p>
 
 table:
@@ -72,14 +72,14 @@ values:
     name: Bold
     information: https://modern.ircdocs.horse/formatting.html#bold
     client-support: 100%
-    client-names: AdiIRC, BitchX, Hexchat, IceChat, Instantbird, IRCCloud, irssi, KiwiIRC, Konversation, KVIrc, mIRC, Quassel, WeeChat
+    client-names: AdiIRC, BitchX, Hexchat, IceChat, Instantbird, IRCCloud, irssi, KiwiIRC, Konversation, KVIrc, The Lounge, mIRC, Quassel, WeeChat
     unique: true
 
   - char: "0x03"
     name: mIRC Color
     information: https://modern.ircdocs.horse/formatting.html#color
     client-support: 100%
-    client-names: AdiIRC, BitchX, Hexchat, IceChat, Instantbird, IRCCloud, irssi, KiwiIRC, Konversation, KVIrc, mIRC, Quassel, WeeChat
+    client-names: AdiIRC, BitchX, Hexchat, IceChat, Instantbird, IRCCloud, irssi, KiwiIRC, Konversation, KVIrc, The Lounge, mIRC, Quassel, WeeChat
     unique: true
   
   - char: "0x04"
@@ -93,7 +93,7 @@ values:
     name: Monospace
     information: https://modern.ircdocs.horse/formatting.html#monospace
     client-support:
-    client-names: IRCCloud
+    client-names: IRCCloud, The Lounge
     unique: true
 
   - char: "0x12"
@@ -108,7 +108,7 @@ values:
     name: Reverse Color
     information: https://modern.ircdocs.horse/formatting.html#reverse-color--or-italics
     client-support: 54%
-    client-names: BitchX, Hexchat, IRCCloud, Irssi, Konversation, KVIrc, WeeChat
+    client-names: BitchX, Hexchat, IRCCloud, Irssi, Konversation, KVIrc, The Lounge, WeeChat
     comment: mIRC doesn't do reverse color but forces the whole rest of the line to be dark-on-light, even if other color codes are given after this character.
     seealso: 0x12 (Reverse Color)
     unique: false
@@ -126,7 +126,7 @@ values:
     name: Strikethrough
     information: https://modern.ircdocs.horse/formatting.html#strikethrough
     client-support:
-    client-names: Textual, IRCCloud
+    client-names: Textual, IRCCloud, The Lounge
     unique: true
 
   - char: "0x0F"
@@ -140,7 +140,7 @@ values:
     name: Italics
     information: https://modern.ircdocs.horse/formatting.html#italics
     client-support: 92%
-    client-names: AdiIRC, Hexchat, IceChat, Instantbird, IRCCloud, Irssi, KiwiIRC, Konversation, KVIrc, mIRC, Quassel, WeeChat
+    client-names: AdiIRC, Hexchat, IceChat, Instantbird, IRCCloud, Irssi, KiwiIRC, Konversation, KVIrc, The Lounge, mIRC, Quassel, WeeChat
     seealso: 0x16 (Italics)
     unique: false
 
@@ -148,5 +148,5 @@ values:
     name: Underline
     information: https://modern.ircdocs.horse/formatting.html#underline
     client-support: 100%
-    client-names: AdiIRC, BitchX, HexChat, IceChat, Instantbird, IRCCloud, Irssi, KiwiIRC, Konversation, KVIrc, mIRC, Quassel, WeeChat
+    client-names: AdiIRC, BitchX, HexChat, IceChat, Instantbird, IRCCloud, Irssi, KiwiIRC, Konversation, KVIrc, The Lounge, mIRC, Quassel, WeeChat
     unique: true


### PR DESCRIPTION
v2.7 adds strikethrough and monospace: https://github.com/thelounge/lounge/pull/1792
