### PR TITLE
Fixed type in numerics.yaml

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -3828,7 +3828,7 @@ values:
         origin: Ultimate
 
     -
-        name: RPL_ENDOFO
+        name: RPL_ENDOFOMOTD
         numeric: "626"
         origin: Ultimate
 

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -3828,7 +3828,7 @@ values:
         origin: Ultimate
 
     -
-        name: RPL_ENDOFO<MOTD
+        name: RPL_ENDOFO
         numeric: "626"
         origin: Ultimate
 


### PR DESCRIPTION
Fixed typo around line 3830 - Changed "name: RPL_ENDOFO<MOTD" to "name: RPL_ENDOFO"