### PR TITLE
Document InspIRCd's conflicting 500 ERR_CANNOTSETMODER

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -3315,6 +3315,16 @@ values:
         conflict: true
 
     -
+        name: ERR_CANNOTSETMODER
+        numeric: "500"
+        origin: InspIRCd
+        format: "<client> :Only a server may modify the +r user/channel mode"
+        comment: >
+            Returned by the server when a client tries to set MODE +r on a user
+            or channel. This mode is set by services for registered users/channels.
+        conflict: true
+
+    -
         name: ERR_UMODEUNKNOWNFLAG
         numeric: "501"
         origin: RFC1459


### PR DESCRIPTION
I made up the name `ERR_CANNOTSETMODER` added here: https://github.com/inspircd/inspircd/commit/566b2a8b00d1b0d251f72c9351998d5c300ada46