### PR TITLE
char arg in ERR_BANLISTFULL isn't sent by all IRCds

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -2951,7 +2951,7 @@ values:
         name: ERR_BANLISTFULL
         numeric: "478"
         origin: RFC2812
-        format: "<client> <channel> <char> :<reason>"
+        format: "<client> <channel> [<char>] :<reason>"
         comment: >
             Returned when a channel access list (i.e. ban list etc) is full
             and cannot be added to


### PR DESCRIPTION
Possibly a server bug but hey.

e.g. https://github.com/inspircd/inspircd/blob/765abf3a41551590219bc8bd4be80b3ff6ba6053/src/modules/m_banredirect.cpp#L85