### PR TITLE
Fix 974 ERR_CANNOTCHANGECHANMODE channel -> client

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4752,7 +4752,7 @@ values:
         name: ERR_CANNOTCHANGECHANMODE
         numeric: "974"
         origin: Unreal
-        format: "<channel> <mode> :<info>"
+        format: "<client> <mode> :<info>"
         conflict: true
         comment: >
             Indicates that a channel mode could not be changeded for an


### PR DESCRIPTION
https://github.com/unrealircd/unrealircd/blob/02d69e7d835e40f0c3b53771587e8f697e8c5424/src/s_err.c#L1021
`:%s 974 %s %c :%s`
https://github.com/unrealircd/unrealircd/blob/02d69e7d835e40f0c3b53771587e8f697e8c5424/src/modules/chanmodes/operonly.c#L104-L105
`me.name` is the server prefix
`cptr->name` is the client name 
`:irc.example.com 974 client O :You are not an IRC operator`