### PR TITLE
ERR_ALLMUSTSSL is actually only used by InspIRCd

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -3198,7 +3198,7 @@ values:
     -
         name: ERR_ALLMUSTSSL
         numeric: "490"
-        origin: "Unreal, apparently"
+        origin: "InspIRCd"
         format: "<client> <channel> :all members of the channel must be connected via SSL"
         conflict: true
 


### PR DESCRIPTION
However, it credits Unreal. Probably an old version, since Unreal only uses ERR_NOSWEAR