### PR TITLE
Document actual 690 usage from InspIRCd

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4007,7 +4007,8 @@ values:
         comment: >
             Used to display the user's TS6 UID in WHOIS.
 
-    -   name: RPL_WHOISLANGUAGE
+    -   
+        name: RPL_WHOISLANGUAGE
         numeric: "690"
         origin: KineIRCd
         format: "<client> <nick> <language codes> :can speak these languages"
@@ -4015,7 +4016,8 @@ values:
              Reply to WHOIS command - A list of languages someone can speak. The language codes are comma delimited
         conflict: true
 
-    -   namme: ERR_REDIRECT
+    -   
+        namme: ERR_REDIRECT
         numeric: "690"
         origin: InspIRCd
         format: "<client> :Target channel #chan must exist to be set as a redirect"

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4008,15 +4008,6 @@ values:
             Used to display the user's TS6 UID in WHOIS.
 
     -   
-        name: RPL_WHOISLANGUAGE
-        numeric: "690"
-        origin: KineIRCd
-        format: "<client> <nick> <language codes> :can speak these languages"
-        comment: >
-             Reply to WHOIS command - A list of languages someone can speak. The language codes are comma delimited
-        conflict: true
-
-    -   
         name: ERR_REDIRECT
         numeric: "690"
         origin: InspIRCd
@@ -4024,7 +4015,6 @@ values:
         comment: >
             Indicates an error when setting a channel redirect (MODE +L)
             or using the banredirect module
-        conflict: true
             
 
     -

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4007,9 +4007,21 @@ values:
         comment: >
             Used to display the user's TS6 UID in WHOIS.
 
-    -   name: RPL_LANGUAGES
+    -   name: RPL_WHOISLANGUAGE
         numeric: "690"
-        origin: Unreal?
+        origin: KineIRCd
+        format: <client> <nick> <language codes> :can speak these languages
+        comment: >
+             Reply to WHOIS command - A list of languages someone can speak. The language codes are comma delimited
+
+    -   namme: ERR_REDIRECT
+        numeric: "690"
+        origin: InspIRCd
+        format: "<client> :Target channel #chan must exist to be set as a redirect"
+        comment: >
+            Indicates an error when setting a channel redirect (MODE +L)
+            or using the banredirect module
+            
 
     -
         name: ERR_STARTTLS

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4010,7 +4010,7 @@ values:
     -   name: RPL_WHOISLANGUAGE
         numeric: "690"
         origin: KineIRCd
-        format: <client> <nick> <language codes> :can speak these languages
+        format: "<client> <nick> <language codes> :can speak these languages"
         comment: >
              Reply to WHOIS command - A list of languages someone can speak. The language codes are comma delimited
 

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4013,6 +4013,7 @@ values:
         format: "<client> <nick> <language codes> :can speak these languages"
         comment: >
              Reply to WHOIS command - A list of languages someone can speak. The language codes are comma delimited
+        conflict: true
 
     -   namme: ERR_REDIRECT
         numeric: "690"
@@ -4021,6 +4022,7 @@ values:
         comment: >
             Indicates an error when setting a channel redirect (MODE +L)
             or using the banredirect module
+        conflict: true
             
 
     -

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4017,7 +4017,7 @@ values:
         conflict: true
 
     -   
-        namme: ERR_REDIRECT
+        name: ERR_REDIRECT
         numeric: "690"
         origin: InspIRCd
         format: "<client> :Target channel #chan must exist to be set as a redirect"


### PR DESCRIPTION
I just chose the ERR_REDIRECT name myself, insp doesn't use a named constant and that one was unused and seemed consistent.