### PR TITLE
Document both 344 RPL_WHOISCOUNTRY formats

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -1766,9 +1766,17 @@ values:
     -
         name: RPL_WHOISCOUNTRY
         numeric: "344"
-        origin: InspIRCd 3.0
-        format: "<client> <country code> :is located in this country"
+        origin: InspIRCd 2.0
+        format: "<client> <nick> :is connected from <country> <country code>"
         comment: "Used by InspIRCd's m_geoip module."
+        conflict: true
+
+    -
+        name: RPL_WHOISCOUNTRY
+        numeric: "344"
+        origin: InspIRCd 3.0
+        format: "<client> <nick> <country code> :is connecting from <country>"
+        comment: "Used by InspIRCd's m_geoban module."
         conflict: true
 
     -


### PR DESCRIPTION
Not sure when the Insp format changed for this numeric, but 2.0 servers (e.g. irc.europnet.org) don't include the country code as a param.

The last change made to the numeric was here but it looks like the previous code also sent the country code separately so I'm not sure when that was changed

https://github.com/inspircd/inspircd/commit/14e1d1f844c89e14cac24799c80af47ed6767cf2

/cc @SaberUK 