### PR TITLE
data: Quassel 0.13+ supports self-message

### DIFF
--- a/_data/selfmessage.yaml
+++ b/_data/selfmessage.yaml
@@ -161,12 +161,9 @@ values:
       works: true
 
     - name: Quassel
-      last-tested-version: "0.12.4"
-      working-since: git
+      working-since: "0.13.0"
       requested-caps: znc.in/self-message
-      works: false
-      unreleased: true
-      comment: Not included in a released version as of feb 2017.
+      works: true
 
     - name: Textual
       working-since: "2.1"


### PR DESCRIPTION
## In short
* Update the `self-message` entry for Quassel now that [0.13.0 has support](https://github.com/quassel/quassel/blob/0.13.0/src/core/ircparser.cpp#L197-L200 )
  * Tested with BitlBee on Quassel 0.13.0 and 0.13.1

*As this is a very small change, I've skipped the usual breakdown and risk analysis*