### PR TITLE
fix argument order for RPL_QUIETLIST (728)

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4317,7 +4317,7 @@ values:
         name: RPL_QUIETLIST
         numeric: "728"
         origin: Charybdis
-        format: "<client> <channel> <banid> q [<time_left> :<reason>]"
+        format: "<client> <channel> q <banid> [<time_left> :<reason>]"
         comment: >
             Same thing as RPL_BANLIST, but for mode +q (quiet)
 


### PR DESCRIPTION
charybdis example:
```
MODE #test +q
:innsbruck.tripsit.me 728 jess|test #test q asd!*@* jess!jess@tripsit/user/Bit 1579688865
:innsbruck.tripsit.me 729 jess|test #test q :End of Channel Quiet List
```

ircd-seven example:
```
MODE #bitbottest +q
:adams.freenode.net 728 jess|test #bitbottest q asd!*@* jess!jess@bitbot/dev/jess 1579688462
:adams.freenode.net 729 jess|test #bitbottest q :End of Channel Quiet List
```