### PR TITLE
add numerics for InspIRCd's m_exemptchanop module

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -4771,6 +4771,20 @@ values:
         comment: "Used by InspIRCd's m_silence module."
 
     -
+        name: RPL_EXEMPTIONLIST
+        numeric: "954"
+        origin: InspIRCd
+        format: "<client> <channel> <exception> <who> :<set-ts>"
+        comment: "Used by InspIRCd's m_exemptchanop module."
+
+    -
+        name: RPL_ENDOFEXEMPTIONLIST
+        numeric: "953"
+        origin: InspIRCd
+        format: "<client> <channel> :End of channel exemptchanops list"
+        comment: "Used by InspIRCd's m_exemptchanop module."
+
+    -
         name: RPL_ENDOFPROPLIST
         numeric: "960"
         origin: InspIRCd


### PR DESCRIPTION
`RPL_` name chosen by myself with permission of @SadieCat.

```
> MODE #test2 +X regmoderated:o
< :jes|test!~j@lolnerd.net MODE #test2 +X :regmoderated:o
> MODE #test2 +X
< :thunix.tilde.chat 954 jes|test #test2 regmoderated:o jes|test :1579798743
< :thunix.tilde.chat 953 jes|test #test2 :End of channel exemptchanops list
```

docs: https://docs.inspircd.org/3/modules/exemptchanops/