### PR TITLE
Fix wrong IRC param number

### DIFF
--- a/_data/isupport.yaml
+++ b/_data/isupport.yaml
@@ -472,7 +472,7 @@ values:
             Indicates the maximum number of parameters to any command.
 
             Used by InspIRCd only, where the default is 32, above the RFC
-            specified limit of 12. Other servers may have different limits
+            specified limit of 15. Other servers may have different limits
             without advertising this token.
 
         examples:


### PR DESCRIPTION
The RFC specifies that messages can have up to 15 parameters, not 12.

see https://tools.ietf.org/html/rfc2812#section-2.3