### PR TITLE
Document ERR_LINKCHANNEL and fix the documentation of +L on Unreal.

### DIFF
--- a/_data/chanmodes.yaml
+++ b/_data/chanmodes.yaml
@@ -420,8 +420,8 @@ values:
         origin: Unreal
         parameter: <channel>
         comment: >
-            If the channel is +l, and the channel is full, users will be
-            redirected to the given channel
+            Forwards users cannot join a channel for some reason (+b, +i, +l,
+            +R, +z, ...), tothe given channel.
 
         conflict: true
 

--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -2890,6 +2890,12 @@ values:
         name: ERR_LINKCHANNEL
         numeric: "470"
         origin: Unreal
+        comment: >
+            Sent by a server to a user who tried to JOIN a channel, when they
+            are forwarded to a different channel because they could not join
+            the original one.
+            The target channel is usually configured with +f (eg. Charybdis)
+            or +L (eg. Unreal)
         conflict: true
 
     -


### PR DESCRIPTION
ERR_LINKCHANNEL is "common knowledge".

This documentation of +L does not match the one in Unreal's
documentation, but it's how it is actually implemented.