### PR TITLE
chanmodes: Clarify use of NO_HIDING on Unreal

### DIFF
--- a/_data/chanmodes.yaml
+++ b/_data/chanmodes.yaml
@@ -330,7 +330,7 @@ values:
             +H for HISTORY (see above)
 
         conflict: true
-        obsolute: true
+        obsolete: true
 
     -
         char: i

--- a/_data/chanmodes.yaml
+++ b/_data/chanmodes.yaml
@@ -330,6 +330,7 @@ values:
             +H for HISTORY (see above)
 
         conflict: true
+        obsolute: true
 
     -
         char: i

--- a/_data/chanmodes.yaml
+++ b/_data/chanmodes.yaml
@@ -321,10 +321,13 @@ values:
     -
         char: H
         name: NO_HIDING
-        origin: Unreal
+        origin: 3rd-party Unreal
         comment: >
             When set, this stops users set umode +I (INVISIBLE_JOINPART)
-            from being able to join or part a channel secretly
+            from being able to join or part a channel secretly.
+            This mode was only implemented by an old and unpopular
+            third-party Unreal module. Starting with v3.2, Unreal uses
+            +H for HISTORY (see above)
 
         conflict: true
 


### PR DESCRIPTION
From a discussion with Unreal devs:

> the famous +I usermode on unreal 3.1 or earlier
> unreal never officially had such a feature to begin with iirc
> there was a third party module around
> but that was heavily frowned upon