### PR TITLE
chanmodes: INVISIBLE_JOINPART is unambiguously obsolote.

### DIFF
--- a/_data/usermodes.yaml
+++ b/_data/usermodes.yaml
@@ -326,7 +326,7 @@ values:
         origin: Unreal
         comment: >
             User is invisible when joining/parting channels. This is
-            supposedly obsolete as of UnrealIRCd 3.2 beta 16
+            obsolete as of UnrealIRCd 3.2 beta 16
 
         obsolete: true
         conflict: true


### PR DESCRIPTION
From an Unreal dev:

> the famous +I usermode on unreal 3.1 or earlier