### PR TITLE
Unobsolete 005 LINELEN.

### DIFF
--- a/_data/isupport.yaml
+++ b/_data/isupport.yaml
@@ -390,14 +390,13 @@ values:
             limit for `"LINELEN"`.
 
             An alternative to this token is the [oragono.io/maxline-2 capability](https://oragono.io/maxline-2),
-            though that has now also been deprecated.
+            though that has now been deprecated.
 
         examples:
             - "LINELEN=512"
             - "LINELEN=2048"
 
         proposed: true
-        obsolete: true
 
     -
         name: MAP


### PR DESCRIPTION
Oragono might have removed this but it is still used by InspIRCd. Without it there's no way for a client to tell if the line length has been changed.


