### PR TITLE
Add ISUPPORT HOSTLEN

### DIFF
--- a/_data/isupport.yaml
+++ b/_data/isupport.yaml
@@ -336,6 +336,16 @@ values:
         obsolete: true
 
     -
+        name: HOSTLEN
+        format: "HOSTLEN=<number>"
+        comment: >
+            Indicates the maximum length of an hostname in octets.
+
+        examples:
+            - "HOSTLEN=63"
+            - "HOSTLEN=100"
+
+    -
         name: INVEX
         format: "INVEX[=letter]"
         information: "https://tools.ietf.org/html/draft-hardy-irc-isupport-00"


### PR DESCRIPTION
It's in modern, but it's missing here:
https://modern.ircdocs.horse/#hostlen-parameter