### PR TITLE
numerics: add RPL_MSGNEEDREGGEDNICK

### DIFF
--- a/_data/numerics.yaml
+++ b/_data/numerics.yaml
@@ -2465,6 +2465,16 @@ values:
             syntax
 
     -
+        name: ERR_MSGNEEDREGGEDNICK
+        numeric: "415"
+        origin: "Solanum, oftc-hybrid"
+        conflict: true
+        comment: >
+            Returned when an unregistered user sends a message to a 
+            channel that only accepts messages coming from users registered to 
+            services.
+
+    -
         name: ERR_TOOMANYMATCHES
         numeric: "416"
         origin: IRCnet


### PR DESCRIPTION
This seems to be used in Solanum and oftc-hybrid. Solanum calls it as such:
```
include/messages.h:#define NUMERIC_STR_415      "%s :Cannot send message to channel (+R) - you need to be logged into your NickServ account"
include/numeric.h:#define ERR_MSGNEEDREGGEDNICK 415
```