### PR TITLE
Depend directly on Jekyll, instead of indirectly through github-pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
-gem "github-pages", group: :jekyll_plugins
+gem "jekyll"
+gem "jekyll-sitemap"


### PR DESCRIPTION
The github-pages gem is not maintained anymore, and depends on old versions of its dependencies, which seem to be incompatible with Netlify's Ruby version.

And it looks like we don't use github-pages, anyway.